### PR TITLE
Fix false violation for unspecified namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#28](https://github.com/fabiodomingues/clj-depend/issues/28): fix violation message from `should not depends on` to `should not depend on`.
 * [#26](https://github.com/fabiodomingues/clj-depend/issues/26): add the `:accesses-layers` option to define the dependencies of a layer in the natural order instead of `:accessed-by-layers`.
+* [#31](https://github.com/fabiodomingues/clj-depend/issues/31): fix regression reporting false positives for namespaces that are not covered by any other layer
 
 ## 0.6.0 (2022-06-01)
 

--- a/src/clj_depend/analyzer.clj
+++ b/src/clj_depend/analyzer.clj
@@ -12,22 +12,22 @@
   [config namespace]
   (some #(when (namespace-belongs-to-layer? config namespace %) %) (keys (:layers config))))
 
-(defn- dependency-layer-can-be-accessed-by-layer?
+(defn- dependency-layer-cannot-be-accessed-by-layer?
   [config dependency-layer layer]
   (when-let [accessed-by-layers (get-in config [:layers dependency-layer :accessed-by-layers])]
-    (some (partial = layer) accessed-by-layers)))
+    (not-any? (partial = layer) accessed-by-layers)))
 
-(defn- layer-can-access-dependency-layer?
+(defn- layer-cannot-access-dependency-layer?
   [config layer dependency-layer]
   (when-let [accesses-layers (get-in config [:layers layer :accesses-layers])]
-    (some (partial = dependency-layer) accesses-layers)))
+    (not-any? (partial = dependency-layer) accesses-layers)))
 
 (defn- violate?
   [config
    {:keys [layer dependency-layer]}]
   (and (not= layer dependency-layer)
-       (not (or (dependency-layer-can-be-accessed-by-layer? config dependency-layer layer)
-                (layer-can-access-dependency-layer? config layer dependency-layer)))))
+       (or (dependency-layer-cannot-be-accessed-by-layer? config dependency-layer layer)
+           (layer-cannot-access-dependency-layer? config layer dependency-layer))))
 
 (defn- layer-and-namespace [config namespace dependency-namespace]
   (when-let [layer (layer-by-namespace config namespace)]

--- a/test/clj_depend/analyzer_test.clj
+++ b/test/clj_depend/analyzer_test.clj
@@ -79,7 +79,14 @@
                                                           :c {:defined-by         ".*\\.c\\..*"
                                                               :accesses-layers #{}}}}
                               :namespaces       namespaces-with-violations
-                              :dependency-graph dependency-graph-with-violations})))))
+                              :dependency-graph dependency-graph-with-violations}))))
+
+  (testing "should return zero violations when layer dependencies are not covered by any other layer"
+    (is (= []
+           (analyzer/analyze {:config           {:layers {:a {:namespaces #{'foo.a.bar}
+                                                              :accessed-by-layers #{}}}}
+                              :namespaces       namespaces
+                              :dependency-graph dependency-graph})))))
 
 (deftest analyze-config-with-namespaces-test
 


### PR DESCRIPTION
When running the latest version, I noticed we introduced a regression in #30 which results in namespaces not covered in any layer (like libraries) being reported as violations.

The cause is when layer config does not contain `:accessed-by-layers` then due to `when-let` the result from `dependency-layer-can-be-accessed-by-layer?` will be nil, which is then negated in `violate?`. Same thing applies for `layer-can-access-dependency-layer?`.

To fix it I flipped the negation.

### Checklist

- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [x] I added a new entry to [CHANGELOG.md](https://github.com/fabiodomingues/clj-depend/blob/main/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
