### PR TITLE
Fixing a typo from `accesses-layers` to `access-layers`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
-* [#33](https://github.com/fabiodomingues/clj-depend/issues/33): Merge default configuration, project configuration and configurations passed as parameter.
-* [#28](https://github.com/fabiodomingues/clj-depend/issues/28): fix violation message from `should not depends on` to `should not depend on`.
-* [#26](https://github.com/fabiodomingues/clj-depend/issues/26): add the `:accesses-layers` option to define the dependencies of a layer in the natural order instead of `:accessed-by-layers`.
-* [#31](https://github.com/fabiodomingues/clj-depend/issues/31): fix regression reporting false positives for namespaces that are not covered by any other layer.
-* [#27](https://github.com/fabiodomingues/clj-depend/issues/27): print violated layers.
+* Fix typo from `accesses-layers` to `access-layers`.
+* Merge default configuration, project configuration and configurations passed as parameter. [#33](https://github.com/fabiodomingues/clj-depend/issues/33)
+* Fix violation message from `should not depends on` to `should not depend on`. [#28](https://github.com/fabiodomingues/clj-depend/issues/28)
+* Add the `:accesses-layers` option to define the dependencies of a layer in the natural order instead of `:accessed-by-layers`. [#26](https://github.com/fabiodomingues/clj-depend/issues/26)
+* Fix regression reporting false positives for namespaces that are not covered by any other layer. [#31](https://github.com/fabiodomingues/clj-depend/issues/31)
+* Print violated layers. [#27](https://github.com/fabiodomingues/clj-depend/issues/27)
 
 ## 0.6.0 (2022-06-01)
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Configuration file (`.clj-depend/config.edn`) for diagram above:
 ```clojure
 {:source-paths #{"src"}
  :layers {:controller {:defined-by         ".*\\.controller\\..*"
-                       :accesses-layers #{:logic :model}}
+                       :access-layers #{:logic :model}}
           :logic      {:defined-by         ".*\\.logic\\..*"
-                       :accesses-layers #{:model}}
+                       :access-layers #{:model}}
           :model      {:defined-by         ".*\\.model\\..*"
-                       :accesses-layers #{}}}}
+                       :access-layers #{}}}}
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -29,14 +29,14 @@ Default: `{}`.
 
 A map where each key is a layer and the value is a map, where:
 - The layer is defined by a regex using the `:defined-by` key or a set of namespaces using the `:namespaces` key.
-- The accesses allowed by it declared using the `:accesses-layers` key, or the accesses that are allowed to the layer using the `:accessed-by-layers` key. Since both keys accept a set of layers.
+- The accesses allowed by it declared using the `:access-layers` key, or the accesses that are allowed to the layer using the `:accessed-by-layers` key. Since both keys accept a set of layers.
 
 Layer configuration example:
 ```clojure
 {:controller {:defined-by         ".*\\.controller\\..*"
-              :accesses-layers #{:logic :model}}
+              :access-layers #{:logic :model}}
  :logic      {:defined-by         ".*\\.logic\\..*"
-              :accesses-layers #{:model}}
+              :access-layers #{:model}}
  :model      {:defined-by         ".*\\.model\\..*"
-              :accesses-layers #{}}}
+              :access-layers #{}}}
 ```

--- a/src/clj_depend/analyzer.clj
+++ b/src/clj_depend/analyzer.clj
@@ -3,8 +3,8 @@
 
 (defn- layer-cannot-access-dependency-layer?
   [config layer dependency-layer]
-  (when-let [accesses-layers (get-in config [:layers layer :accesses-layers])]
-    (not-any? (partial = dependency-layer) accesses-layers)))
+  (when-let [access-layers (get-in config [:layers layer :access-layers])]
+    (not-any? (partial = dependency-layer) access-layers)))
 
 (defn- dependency-layer-cannot-be-accessed-by-layer?
   [config dependency-layer layer]

--- a/src/clj_depend/api.clj
+++ b/src/clj_depend/api.clj
@@ -29,8 +29,8 @@
   ```clojure
   (clj-depend.api/analyze {:project-root (io/file \".\")
                            :config {:source-paths #{\"src\"
-                                    :layers {:foo {:defined-by \"foo\\..*\" :accesses-layers #{:bar}}
-                                             :bar {:defined-by \"bar\\..*\" :accesses-layers #{}}}}}
+                                    :layers {:foo {:defined-by \"foo\\..*\" :access-layers #{:bar}}
+                                             :bar {:defined-by \"bar\\..*\" :access-layers #{}}}}}
                            :namespaces #{foo.x bar.y}})
   ```"
   [{:keys [project-root config files namespaces] :as options}]

--- a/test/clj_depend/analyzer_test.clj
+++ b/test/clj_depend/analyzer_test.clj
@@ -77,11 +77,11 @@
              :dependency-layer :b
              :message "\"foo.c.bar\" should not depend on \"foo.b.bar\" (layer \":c\" on \":b\")"}]
            (analyzer/analyze {:config           {:layers {:a {:defined-by         ".*\\.a\\..*"
-                                                              :accesses-layers #{:b :c}}
+                                                              :access-layers #{:b :c}}
                                                           :b {:defined-by         ".*\\.b\\..*"
-                                                              :accesses-layers #{:c}}
+                                                              :access-layers #{:c}}
                                                           :c {:defined-by         ".*\\.c\\..*"
-                                                              :accesses-layers #{}}}}
+                                                              :access-layers #{}}}}
                               :namespaces       namespaces-with-violations
                               :dependency-graph dependency-graph-with-violations}))))
 


### PR DESCRIPTION
Fixing a typo from `accesses-layers` to `access-layers`.

### Checklist

- [ ] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [X] I added a new entry to [CHANGELOG.md](https://github.com/fabiodomingues/clj-depend/blob/main/CHANGELOG.md)
- [X] I updated documentation if applicable (`docs` folder)
