### PR TITLE
Adding feature to dump violations into a snapshot file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
+* [#1](https://github.com/fabiodomingues/clj-depend/issues/1): Dump the violations into a snapshot file (`.clj-depend/violations.edn`), and ignore any violations that are present in the snapshot file in future analysis.
 * [#33](https://github.com/fabiodomingues/clj-depend/issues/33): Merge default configuration, project configuration and configurations passed as parameter.
-* [#28](https://github.com/fabiodomingues/clj-depend/issues/28): fix violation message from `should not depends on` to `should not depend on`.
-* [#26](https://github.com/fabiodomingues/clj-depend/issues/26): add the `:accesses-layers` option to define the dependencies of a layer in the natural order instead of `:accessed-by-layers`.
-* [#31](https://github.com/fabiodomingues/clj-depend/issues/31): fix regression reporting false positives for namespaces that are not covered by any other layer.
-* [#27](https://github.com/fabiodomingues/clj-depend/issues/27): print violated layers.
+* [#28](https://github.com/fabiodomingues/clj-depend/issues/28): Fix violation message from `should not depends on` to `should not depend on`.
+* [#26](https://github.com/fabiodomingues/clj-depend/issues/26): Add the `:accesses-layers` option to define the dependencies of a layer in the natural order instead of `:accessed-by-layers`.
+* [#31](https://github.com/fabiodomingues/clj-depend/issues/31): Fix regression reporting false positives for namespaces that are not covered by any other layer.
+* [#27](https://github.com/fabiodomingues/clj-depend/issues/27): Print violated layers.
 
 ## 0.6.0 (2022-06-01)
 

--- a/src/clj_depend/api.clj
+++ b/src/clj_depend/api.clj
@@ -15,6 +15,8 @@
 
   - `:namespaces` optional, a set of symbols representing namespaces to be analyzed. If empty, all project namespaces will be considered.
 
+  - `:snapshot?` a boolean, when enable analyze namespace dependencies and dump the violations into a snapshot file (`.clj-depend/violations.edn`) that is used as a reference for further analysis.
+
   Returns a map with:
 
   - `:result-code` required, an integer:

--- a/src/clj_depend/internal_api.clj
+++ b/src/clj_depend/internal_api.clj
@@ -3,6 +3,7 @@
             [clj-depend.config :as config]
             [clj-depend.dependency :as dependency]
             [clj-depend.parser :as parser]
+            [clj-depend.snapshot :as snapshot]
             [clojure.java.io :as io]
             [clojure.string :as string]))
 
@@ -44,7 +45,9 @@
   [options]
   (try
     (let [context (build-context options)
-          violations (analyzer/analyze context)]
+          violations (analyzer/analyze context)
+          _ (snapshot/dump-when-enabled! violations options)
+          violations (snapshot/without-violations-present-in-snapshot-file! violations options)]
       (if (seq violations)
         {:result-code 1
          :message     (string/join "\n" (map :message violations))

--- a/src/clj_depend/main.clj
+++ b/src/clj_depend/main.clj
@@ -19,7 +19,10 @@
     :id :source-paths
     :validate [#(not (string/includes? (str %) " ")) "Namespaces should be separated by comma."]
     :assoc-fn #(assoc %1 %2 (->> (string/split %3 #",")
-                                 (map symbol)))]])
+                                 (map symbol)))]
+   [nil "--snapshot" "Analyze namespace dependencies and dump the violations into a snapshot file (`.clj-depend/violations.edn`) that is used as a reference for further analysis."
+    :id :snapshot?
+    :default false]])
 
 (defn- exit!
   [exit-code message]

--- a/src/clj_depend/snapshot.clj
+++ b/src/clj_depend/snapshot.clj
@@ -1,0 +1,27 @@
+(ns clj-depend.snapshot
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io])
+  (:import (java.io PushbackReader)))
+
+(defn without-violations-present-in-snapshot-file!
+  [violations
+   {:keys [project-root]}]
+  (let [snapshot-violations-file (io/file project-root ".clj-depend" "violations.edn")]
+    (if (.exists snapshot-violations-file)
+      (with-open [reader (PushbackReader. (io/reader snapshot-violations-file))]
+        (let [snapshot-violations (edn/read reader)
+              snapshot-violations-no-longer-needed (remove (fn [snapshot-violation] (some #(= snapshot-violation %) violations)) snapshot-violations)]
+          (when (not-empty snapshot-violations-no-longer-needed)
+            (throw (ex-info "The code has been improved, and one or more violations present in the clj-depend violations snapshot file are no longer needed. Please run clj-depend with the `--snapshot` option to update the snapshot file and commit the changes. For more information check the documentation at http://xxx.com."
+                            {:reason ::snapshot-violations-no-longer-needed
+                             :violations-no-longer-needed snapshot-violations-no-longer-needed})))
+          (remove (fn [violation] (some #(= violation %) snapshot-violations)) violations)))
+      violations)))
+
+(defn dump-when-enabled!
+  [violations
+   {:keys [project-root snapshot?]}]
+  (when snapshot?
+    (let [snapshot-violations-file (io/file project-root ".clj-depend" "violations.edn")]
+      (with-open [w (clojure.java.io/writer snapshot-violations-file)]
+        (.write w (pr-str violations))))))

--- a/test-resources/without-violations-and-snapshot-violations-no-longer-needed/.clj-depend/config.edn
+++ b/test-resources/without-violations-and-snapshot-violations-no-longer-needed/.clj-depend/config.edn
@@ -1,0 +1,7 @@
+{:source-paths #{"src"}
+ :layers       {:server     {:namespaces         #{sample.server}
+                             :accessed-by-layers #{}}
+                :controller {:defined-by         ".*\\.controller\\..*"
+                             :accessed-by-layers #{:server}}
+                :logic      {:defined-by         ".*\\.logic\\..*"
+                             :accessed-by-layers #{:controller}}}}

--- a/test-resources/without-violations-and-snapshot-violations-no-longer-needed/.clj-depend/violations.edn
+++ b/test-resources/without-violations-and-snapshot-violations-no-longer-needed/.clj-depend/violations.edn
@@ -1,0 +1,1 @@
+({:namespace sample.logic.foo, :dependency-namespace sample.controller.foo, :layer :logic, :dependency-layer :controller, :message "\"sample.logic.foo\" should not depend on \"sample.controller.foo\" (layer \":logic\" on \":controller\")"})

--- a/test-resources/without-violations-and-snapshot-violations-no-longer-needed/src/sample/controller/foo.clj
+++ b/test-resources/without-violations-and-snapshot-violations-no-longer-needed/src/sample/controller/foo.clj
@@ -1,0 +1,2 @@
+(ns sample.controller.foo
+  (:require [sample.logic.foo :as logic.foo]))

--- a/test-resources/without-violations-and-snapshot-violations-no-longer-needed/src/sample/logic/bar.clj
+++ b/test-resources/without-violations-and-snapshot-violations-no-longer-needed/src/sample/logic/bar.clj
@@ -1,0 +1,2 @@
+(ns without-violations.src.sample.logic.bar
+  (:require [sample.logic.foo :as logic.foo]))

--- a/test-resources/without-violations-and-snapshot-violations-no-longer-needed/src/sample/logic/foo.clj
+++ b/test-resources/without-violations-and-snapshot-violations-no-longer-needed/src/sample/logic/foo.clj
@@ -1,0 +1,1 @@
+(ns sample.logic.foo)

--- a/test-resources/without-violations-and-snapshot-violations-no-longer-needed/src/sample/server.clj
+++ b/test-resources/without-violations-and-snapshot-violations-no-longer-needed/src/sample/server.clj
@@ -1,0 +1,2 @@
+(ns sample.server
+  (:require [sample.controller.foo :as controller.foo]))


### PR DESCRIPTION
## Context

Dump the violations into a snapshot file (`.clj-depend/violations.edn`), and ignore any violations that are present in the snapshot file in future analysis.

Fixes https://github.com/fabiodomingues/clj-depend/issues/1

### Checklist

- [X] I created an issue to discuss the problem I am trying to solve or an open issue already exists.
- [X] I added a new entry to [CHANGELOG.md](https://github.com/fabiodomingues/clj-depend/blob/main/CHANGELOG.md)
- [ ] I updated documentation if applicable (`docs` folder)
